### PR TITLE
Se elimina una linea de espacio en el enum BankAccountType

### DIFF
--- a/src/patterns/builder/BankAccountType.java
+++ b/src/patterns/builder/BankAccountType.java
@@ -3,5 +3,4 @@ package patterns.builder;
 public enum BankAccountType {
 
 	PLATINUM, GOLDEN, STANDAR
-
 }


### PR DESCRIPTION
Bug-fixing
Se elimina una linea de espacio en el enum BankAccountType